### PR TITLE
Better list handling for Roff manpages

### DIFF
--- a/mrkd.py
+++ b/mrkd.py
@@ -87,10 +87,16 @@ class RoffRenderer(mistune.Renderer):
                 buf.write(chunk)
                 count += 1
 
-            return lines(buf.getvalue())
+            return lines(
+                '.RS',
+                buf.getvalue(),
+                '.RE'
+            )
         else:
             return lines(
+                '.RS',
                 body.replace('\0', '.IP \\[bu]'),
+                '.RE'
             )
 
     def list_item(self, text):


### PR DESCRIPTION
Line indentation is weirdly rendered when not between `.RS` and `.RE`, and that was the case when converting a Markdown list to a Roff manpage list.