### PR TITLE
Set mistune version to 0.8.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         'console_scripts': ['mrkd=mrkd:main'],
     },
     include_package_data=True,
-    install_requires=['Jinja2', 'mistune', 'pygments'],
+    install_requires=['Jinja2', 'mistune == 0.8.4', 'pygments'],
     classifiers=[
         'Programming Language :: Python :: 3 :: Only',
         'License :: OSI Approved :: BSD License',


### PR DESCRIPTION
- prevent breaking changes introduced by v2

I tried to build [clightning](https://github.com/ElementsProject/lightning) following build instructions [here](https://github.com/ElementsProject/lightning/blob/master/doc/INSTALL.md#to-build-on-ubuntu), and after doing a `pip3 install --user mrkd` `make` would fail with the following error:
```
mrkd doc/lightning-cli.1.md
Traceback (most recent call last):
  File "/home/sosthene/.local/bin/mrkd", line 5, in <module>
    from mrkd import main
  File "/home/sosthene/.local/lib/python3.8/site-packages/mrkd/__init__.py", line 23, in <module>
    class ReferenceLexer(mistune.InlineLexer):
AttributeError: module 'mistune' has no attribute 'InlineLexer'
make: *** [doc/Makefile:115: doc/lightning-cli.1] Error 1
```

It seems that mistune v2 doesn't have the `InlineLexer` class anymore. 

I set the mistune version to the last v1 version, and it solves the problem at least for what I'm trying to do (build Lightning). 

Even better would be to rewrite the code to be compatible with mistune v2, but I'm not very familiar with it. 